### PR TITLE
Disable/Enable Signup & Login buttons

### DIFF
--- a/app/src/main/java/com/criticove/Login.kt
+++ b/app/src/main/java/com/criticove/Login.kt
@@ -62,6 +62,11 @@ fun LoginMainContent(navController: NavController) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
 
+    var isLoginEnabled by remember { mutableStateOf(false) }
+    fun checkLoginEnabled() {
+        isLoginEnabled = email.isNotBlank() && password.isNotBlank()
+    }
+
     var errorMessage by remember { mutableStateOf("") }
 
     Column(
@@ -109,9 +114,15 @@ fun LoginMainContent(navController: NavController) {
                 fontSize = 18.sp
             )
 
-            OutlinedTextFieldLogin("Email") { email = it }
+            OutlinedTextFieldLogin("Email") {
+                email = it
+                checkLoginEnabled()
+            }
 
-            OutlinedTextFieldLogin("Password", true) { password = it }
+            OutlinedTextFieldLogin("Password", true) {
+                password = it
+                checkLoginEnabled()
+            }
 
             Button(
                 onClick = {
@@ -124,6 +135,7 @@ fun LoginMainContent(navController: NavController) {
                         }
                     }
                 },
+                enabled = isLoginEnabled,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = colorResource(id = R.color.teal),
                     contentColor = colorResource(id = R.color.yellow)

--- a/app/src/main/java/com/criticove/Signup.kt
+++ b/app/src/main/java/com/criticove/Signup.kt
@@ -98,6 +98,12 @@ fun SignupMainContent(navController: NavController) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
 
+    var isSignupEnabled by remember { mutableStateOf(false) }
+    fun checkSignupEnabled() {
+        isSignupEnabled = username.isNotBlank() && email.isNotBlank()
+                && password.isNotBlank()
+    }
+
     var errorMessage by remember { mutableStateOf("") }
 
     Column(
@@ -144,11 +150,20 @@ fun SignupMainContent(navController: NavController) {
                 fontSize = 18.sp
             )
 
-            OutlinedTextFieldSignup("Username") { username = it }
+            OutlinedTextFieldSignup("Username") {
+                username = it
+                checkSignupEnabled()
+            }
 
-            OutlinedTextFieldSignup("Email") { email = it }
+            OutlinedTextFieldSignup("Email") {
+                email = it
+                checkSignupEnabled()
+            }
 
-            OutlinedTextFieldSignup("Password", true) { password = it }
+            OutlinedTextFieldSignup("Password", true) {
+                password = it
+                checkSignupEnabled()
+            }
 
             Button(
                 onClick = {
@@ -166,6 +181,7 @@ fun SignupMainContent(navController: NavController) {
                         }
                     }
                 },
+                enabled = isSignupEnabled,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = colorResource(id = R.color.teal),
                     contentColor = colorResource(id = R.color.yellow)


### PR DESCRIPTION
- Checks for user inputs on auth pages
- As long as any field is blank (or if all fields are filled and then a field is edited to be blank), signup/login button is disabled
- When all fields contain input, button is enabled
